### PR TITLE
Require Composer WordPress autoloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 Nothing yet.
 
+## 2.0.1
+
+### Fixed
+
+- Missing `alleyinteractive/composer-wordpress-autoloader` dependency.
+
 ## 2.0.0
 
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
     "php": "^8.0",
-    "alleyinteractive/composer-wordpress-autoloader": "^v1.0.0"
+    "alleyinteractive/composer-wordpress-autoloader": "^1.0.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "lock": false
   },
   "require": {
-    "php": "^8.0"
+    "php": "^8.0",
+    "alleyinteractive/composer-wordpress-autoloader": "^v1.0.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^1.0.0",


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

### Fixed

- Missing `alleyinteractive/composer-wordpress-autoloader` dependency.

### Security
